### PR TITLE
Update groupby() to handle being passed an empty iterator

### DIFF
--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -279,7 +279,10 @@ async def groupby(
     grouping: List[T] = []
 
     it = iter(itr)
-    item = await next(it)
+    try:
+        item = await next(it)
+    except StopAsyncIteration:
+        return
     grouping = [item]
 
     j = await maybe_await(key(item))

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -341,6 +341,15 @@ class ItertoolsTest(TestCase):
             await ait.next(it)
 
     @async_test
+    async def test_groupby_empty(self):
+        async def gen():
+            for _ in range(0):
+                yield  # Force generator with no actual iteration
+
+        async for _ in ait.groupby(gen()):
+            self.fail("No iteration should have happened")
+
+    @async_test
     async def test_islice_bad_range(self):
         with self.assertRaisesRegex(ValueError, "must pass stop index"):
             async for _ in ait.islice([1, 2]):


### PR DESCRIPTION
### Description

I noticed today that `groupby()` doesn't handle being passed an empty iterator, unlike the builtin `itertools.groupby()`, and lets the `StopAsyncIteration` bubble up. This PR fixes that and validates it with a test case.
