### PR TITLE
Added implementations for any and all

### DIFF
--- a/aioitertools/__init__.py
+++ b/aioitertools/__init__.py
@@ -8,7 +8,20 @@ itertools and builtins for AsyncIO and mixed iterables
 __author__ = "John Reese"
 from . import asyncio
 from .__version__ import __version__
-from .builtins import enumerate, iter, list, map, max, min, next, set, sum, zip
+from .builtins import (
+    all,
+    any,
+    enumerate,
+    iter,
+    list,
+    map,
+    max,
+    min,
+    next,
+    set,
+    sum,
+    zip,
+)
 from .itertools import (
     accumulate,
     chain,

--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -11,8 +11,8 @@ import asyncio
 import time
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, Set, Tuple, cast
 
-from .types import AsyncIterator, MaybeAwaitable, AnyIterable, T
 from .builtins import maybe_await, iter as aiter
+from .types import AsyncIterator, MaybeAwaitable, AnyIterable, T
 
 
 async def as_completed(

--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -11,7 +11,8 @@ import asyncio
 import time
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, Set, Tuple, cast
 
-from .types import AsyncIterator, T
+from .types import AsyncIterator, MaybeAwaitable, AnyIterable, T
+from .builtins import maybe_await, iter as aiter
 
 
 async def as_completed(
@@ -129,3 +130,22 @@ async def gather(
             ret[lst[i]] = ret[lst[0]]
 
     return ret
+
+
+async def gather_iter(
+    itr: AnyIterable[MaybeAwaitable[T]],
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    return_exceptions: bool = False,
+    limit: int = -1,
+) -> List[T]:
+    """Wrapper around gather to handle gathering an iterable instead
+    of *args.
+
+    Note that the iterable values don't have to be awaitable.
+    """
+    return await gather(
+        *[maybe_await(i) async for i in aiter(itr)],
+        loop=loop,
+        return_exceptions=return_exceptions,
+        limit=limit,
+    )

--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -30,16 +30,31 @@ from typing import (
 )
 
 from .helpers import Orderable, maybe_await
-from .types import T1, T2, T3, T4, T5, AnyIterable, AnyIterator, AnyStop, R, T
+from .types import (
+    T1,
+    T2,
+    T3,
+    T4,
+    T5,
+    AnyIterable,
+    AnyIterator,
+    AnyStop,
+    R,
+    T,
+    MaybeAwaitable,
+)
+from . import asyncio as ait_asyncio
 
 
 class Sentinel(Enum):
     MISSING = object()
 
 
-async def all(itr: AnyIterable[T]) -> bool:
+async def all(itr: AnyIterable[MaybeAwaitable[Any]]) -> bool:
     """
     Return True if all values are truthy in a mixed iterable, else False.
+    The iterable will be fully consumed and any awaitables will
+    automatically be awaited.
 
     Example:
 
@@ -47,15 +62,14 @@ async def all(itr: AnyIterable[T]) -> bool:
             ...
 
     """
-    async for item in iter(itr):
-        if not item:
-            return False
-    return True
+    return builtins.all(await ait_asyncio.gather_iter(itr))
 
 
-async def any(itr: AnyIterable[T]) -> bool:
+async def any(itr: AnyIterable[MaybeAwaitable[Any]]) -> bool:
     """
     Return True if any value is truthy in a mixed iterable, else False.
+    The iterable will be fully consumed and any awaitables will
+    automatically be awaited.
 
     Example:
 
@@ -63,10 +77,7 @@ async def any(itr: AnyIterable[T]) -> bool:
             ...
 
     """
-    async for item in iter(itr):
-        if item:
-            return True
-    return False
+    return builtins.any(await ait_asyncio.gather_iter(itr))
 
 
 def iter(itr: AnyIterable[T]) -> AsyncIterator[T]:

--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -37,6 +37,38 @@ class Sentinel(Enum):
     MISSING = object()
 
 
+async def all(itr: AnyIterable[T]) -> bool:
+    """
+    Return True if all values are truthy in a mixed iterable, else False.
+
+    Example:
+
+        if await all(it):
+            ...
+
+    """
+    async for item in iter(itr):
+        if not item:
+            return False
+    return True
+
+
+async def any(itr: AnyIterable[T]) -> bool:
+    """
+    Return True if any value is truthy in a mixed iterable, else False.
+
+    Example:
+
+        if await any(it):
+            ...
+
+    """
+    async for item in iter(itr):
+        if item:
+            return True
+    return False
+
+
 def iter(itr: AnyIterable[T]) -> AsyncIterator[T]:
     """
     Get an async iterator from any mixed iterable.

--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -29,6 +29,7 @@ from typing import (
     overload,
 )
 
+from . import asyncio as ait_asyncio  # pylint: disable=cyclic-import,reimported
 from .helpers import Orderable, maybe_await
 from .types import (
     T1,
@@ -43,7 +44,6 @@ from .types import (
     T,
     MaybeAwaitable,
 )
-from . import asyncio as ait_asyncio
 
 
 class Sentinel(Enum):

--- a/aioitertools/tests/builtins.py
+++ b/aioitertools/tests/builtins.py
@@ -10,9 +10,58 @@ from .helpers import async_test
 
 slist = ["A", "B", "C"]
 srange = range(3)
+srange1 = range(1, 4)
+srange0 = range(1)
 
 
 class BuiltinsTest(TestCase):
+
+    # aioitertools.all()
+
+    @async_test
+    async def test_all_list(self):
+        self.assertTrue(await ait.all([True, 1, "string"]))
+        self.assertFalse(await ait.all([True, 0, "string"]))
+
+    @async_test
+    async def test_all_range(self):
+        self.assertTrue(await ait.all(srange1))
+        self.assertFalse(await ait.all(srange))
+
+    @async_test
+    async def test_all_generator(self):
+        self.assertTrue(await ait.all(x for x in srange1))
+        self.assertFalse(await ait.all(x for x in srange))
+
+    @async_test
+    async def test_all_async_generator(self):
+        self.assertTrue(await ait.all(ait.iter(srange1)))
+        self.assertFalse(await ait.all(ait.iter(srange)))
+
+    # aioitertools.any()
+
+    @async_test
+    async def test_any_list(self):
+        self.assertTrue(await ait.any([False, 1, ""]))
+        self.assertFalse(await ait.any([False, 0, ""]))
+
+    @async_test
+    async def test_any_range(self):
+        self.assertTrue(await ait.any(srange))
+        self.assertTrue(await ait.any(srange1))
+        self.assertFalse(await ait.any(srange0))
+
+    @async_test
+    async def test_any_generator(self):
+        self.assertTrue(await ait.any(x for x in srange))
+        self.assertTrue(await ait.any(x for x in srange1))
+        self.assertFalse(await ait.any(x for x in srange0))
+
+    @async_test
+    async def test_any_async_generator(self):
+        self.assertTrue(await ait.any(ait.iter(srange)))
+        self.assertTrue(await ait.any(ait.iter(srange1)))
+        self.assertFalse(await ait.any(ait.iter(srange0)))
 
     # aioitertools.iter()
 

--- a/aioitertools/types.py
+++ b/aioitertools/types.py
@@ -29,3 +29,4 @@ AnyStop = (StopIteration, StopAsyncIteration)
 Accumulator = Union[Callable[[T, T], T], Callable[[T, T], Awaitable[T]]]
 KeyFunction = Union[Callable[[T], R], Callable[[T], Awaitable[R]]]
 Predicate = Union[Callable[[T], object], Callable[[T], Awaitable[object]]]
+MaybeAwaitable = Union[T, Awaitable[T]]


### PR DESCRIPTION
### Description

Added implementations for `any()` and `all()` to complement other builtin implementations
