### PR TITLE
Handle exceptions properly in tee

### DIFF
--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -502,7 +502,9 @@ def tee(itr: AnyIterable[T], n: int = 2) -> Tuple[AsyncIterator[T], ...]:
         if k == 0:
             try:
                 async for value in iter(itr):
-                    await asyncio.gather(*[queue.put((None, value)) for queue in queues[1:]])
+                    await asyncio.gather(
+                        *[queue.put((None, value)) for queue in queues[1:]]
+                    )
                     yield value
             except Exception as e:
                 await asyncio.gather(*[queue.put((e, None)) for queue in queues[1:]])

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -512,12 +512,12 @@ def tee(itr: AnyIterable[T], n: int = 2) -> Tuple[AsyncIterator[T], ...]:
 
         else:
             while True:
-                is_exception, value = await q.get()
+                is_exception, item = await q.get()
                 if is_exception:
-                    raise value
-                if value is sentinel:
+                    raise item
+                if item is sentinel:
                     break
-                yield value
+                yield item
 
     return tuple(gen(k, q) for k, q in builtins.enumerate(queues))
 

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -695,6 +695,33 @@ class ItertoolsTest(TestCase):
                 await ait.next(it)
 
     @async_test
+    async def test_tee_propagate_exception(self):
+        class MyError(Exception):
+            pass
+
+        async def gen():
+            yield 1
+            yield 2
+            raise MyError
+
+        async def consumer(it):
+            result = 0
+            async for item in it:
+                result += item
+            return result
+
+        it1, it2 = ait.tee(gen())
+
+        values = await asyncio.gather(
+            consumer(it1),
+            consumer(it2),
+            return_exceptions=True,
+        )
+
+        for value in values:
+            self.assertIsInstance(value, MyError)
+
+    @async_test
     async def test_zip_longest_range(self):
         a = range(3)
         b = range(5)


### PR DESCRIPTION
### Description

When the input async generator raises exception, the exception is not propagated.
This can be an issue when using `asyncio.gather(..., return_exceptions=True)`.

Fixes: This fixes `tee` to propagate the exception to the others.
