### PR TITLE
Improve dependencies for Python 3.8+

### DIFF
--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -2,11 +2,15 @@
 # Licensed under the MIT license
 
 import inspect
+import sys
 from typing import Awaitable, Union
 
-from typing_extensions import Protocol
-
 from .types import T
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol  # pylint: disable=no-name-in-module
 
 
 class Orderable(Protocol):  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://aioitertools.omnilib.dev"
-requires = ["typing_extensions>=3.7"]
+requires = ["typing_extensions>=3.7; python_version < '3.8'"]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-typing_extensions>=3.7
+typing_extensions>=3.7;python_version<"3.8"


### PR DESCRIPTION
Currently, `aioitertools` always depends on `typing_extensions` for `Protocol` which was added to `typing` in Python 3.8. This PR updates `aioitertools` to only depend on `typing_extensions` on 3.6 and 3.7.
