### PR TITLE
Deprecate and ignore loop parameter to asyncio functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -32,7 +32,6 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
-        if: ${{ matrix.python-version != '3.9' }}
       - name: Coverage
         run: codecov --token ${{ secrets.CODECOV_TOKEN }} --branch ${{ github.ref }}
         continue-on-error: true

--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -12,9 +12,11 @@ import time
 from typing import Any, Awaitable, cast, Dict, Iterable, List, Optional, Set, Tuple
 
 from .builtins import iter as aiter, maybe_await
+from .helpers import deprecated_wait_param
 from .types import AnyIterable, AsyncIterator, MaybeAwaitable, T
 
 
+@deprecated_wait_param
 async def as_completed(
     aws: Iterable[Awaitable[T]],
     *,
@@ -59,7 +61,6 @@ async def as_completed(
             Tuple[Set[Awaitable[T]], Set[Awaitable[T]]],
             await asyncio.wait(
                 pending,
-                loop=loop,
                 timeout=remaining,
                 return_when=asyncio.FIRST_COMPLETED,
             ),
@@ -69,6 +70,7 @@ async def as_completed(
             yield await item
 
 
+@deprecated_wait_param
 async def gather(
     *args: Awaitable[T],
     loop: Optional[asyncio.AbstractEventLoop] = None,
@@ -124,7 +126,7 @@ async def gather(
         if pending:
             try:
                 done, pending = await asyncio.wait(
-                    pending, loop=loop, return_when=asyncio.FIRST_COMPLETED
+                    pending, return_when=asyncio.FIRST_COMPLETED
                 )
                 for x in done:
                     if return_exceptions and x.exception():
@@ -136,7 +138,7 @@ async def gather(
                 for x in pending:
                     x.cancel()
                 # we insure that all tasks are cancelled before we raise
-                await asyncio.gather(*pending, loop=loop, return_exceptions=True)
+                await asyncio.gather(*pending, return_exceptions=True)
                 raise
 
         if not pending and next_arg == len(args):
@@ -149,6 +151,7 @@ async def gather(
     return ret
 
 
+@deprecated_wait_param
 async def gather_iter(
     itr: AnyIterable[MaybeAwaitable[T]],
     loop: Optional[asyncio.AbstractEventLoop] = None,
@@ -162,7 +165,6 @@ async def gather_iter(
     """
     return await gather(
         *[maybe_await(i) async for i in aiter(itr)],
-        loop=loop,
         return_exceptions=return_exceptions,
         limit=limit,
     )

--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -3,9 +3,11 @@
 
 import inspect
 import sys
-from typing import Awaitable, Union
+import warnings
+from functools import wraps
+from typing import Awaitable, Callable, Union
 
-from .types import T
+from .types import P, R, T
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
@@ -25,3 +27,19 @@ async def maybe_await(object: Union[Awaitable[T], T]) -> T:
     if inspect.isawaitable(object):
         return await object  # type: ignore
     return object  # type: ignore
+
+
+def deprecated_wait_param(fn: Callable[P, R]) -> Callable[P, R]:
+    @wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        if "loop" in kwargs:  # type: ignore
+            warnings.warn(
+                f"{fn.__name__}() parameter `loop` is deprecated and ignored, "
+                "will be removed in aioitertools v0.11.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/aioitertools/types.py
+++ b/aioitertools/types.py
@@ -1,6 +1,8 @@
 # Copyright 2018 John Reese
 # Licensed under the MIT license
 
+import sys
+
 from typing import (
     AsyncIterable,
     AsyncIterator,
@@ -12,6 +14,13 @@ from typing import (
     Union,
 )
 
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
+
+P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")
 T1 = TypeVar("T1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://aioitertools.omnilib.dev"
-requires = ["typing_extensions>=3.7; python_version < '3.8'"]
+requires = ["typing_extensions>=4.0; python_version < '3.10'"]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-typing_extensions>=3.7;python_version<"3.8"
+typing_extensions>=4.0;python_version<"3.10"


### PR DESCRIPTION
The asyncio `loop` parameter has been deprecated since Python 3.8
and is removed in Python 3.10. This deprecates use of the loop
parameter in aioitertools, and the parameters will be removed
with or after the release of aioitertools v0.11.0.

Adds a decorator `deprecated_wait_param()` that emits deprecation
warnings if the decorated functions are passed the `loop` kwarg.

Adds `@deprecated_wait_param` decorator to `as_completed()`,
`gather()`, and `gather_iter()` functions. The `loop` parameter
is no longer used, even if passed, so that aioitertools will work
on Python 3.10 runtimes.

Fixes #84