### PR TITLE
Improve cancellation semantics and unawaited tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,3 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
-      - name: Coverage
-        run: codecov --token ${{ secrets.CODECOV_TOKEN }} --branch ${{ github.ref }}
-        continue-on-error: true

--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -48,6 +48,9 @@ async def as_completed(
         if timeout:
             remaining = threshold - time.time()
             if remaining <= 0:
+                for fut in pending:
+                    if isinstance(fut, asyncio.Future):
+                        fut.cancel()
                 raise asyncio.TimeoutError()
 
         # asyncio.Future inherits from typing.Awaitable

--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -415,8 +415,9 @@ async def zip(*itrs: AnyIterable[Any]) -> AsyncIterator[Tuple[Any, ...]]:
     its: List[AsyncIterator[Any]] = [iter(itr) for itr in itrs]
 
     while True:
-        try:
-            values = await asyncio.gather(*[it.__anext__() for it in its])
-            yield values
-        except AnyStop:
+        values = await asyncio.gather(
+            *[it.__anext__() for it in its], return_exceptions=True
+        )
+        if builtins.any(isinstance(v, AnyStop) for v in values):
             break
+        yield values

--- a/aioitertools/tests/builtins.py
+++ b/aioitertools/tests/builtins.py
@@ -357,3 +357,12 @@ class BuiltinsTest(TestCase):
             self.assertEqual(a, slist[idx])
             self.assertEqual(b, srange[idx])
             idx += 1
+
+    @async_test
+    async def test_zip_shortest(self):
+        short = ["a", "b", "c"]
+        long = [0, 1, 2, 3, 5]
+
+        result = await ait.list(ait.zip(short, long))
+        expected = [["a", 0], ["b", 1], ["c", 2]]
+        self.assertListEqual(expected, result)

--- a/aioitertools/tests/helpers.py
+++ b/aioitertools/tests/helpers.py
@@ -10,8 +10,13 @@ from aioitertools.helpers import deprecated_wait_param, maybe_await
 
 def async_test(fn):
     def wrapped(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(fn(*args, **kwargs))
+        try:
+            loop = asyncio.new_event_loop()
+            loop.set_debug(False)
+            result = loop.run_until_complete(fn(*args, **kwargs))
+            return result
+        finally:
+            loop.close()
 
     return wrapped
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 attribution==1.5.2
 black==22.1.0
-codecov==2.1.12
 coverage[toml]==6.2
 flake8==4.0.1
 flit==3.6.0


### PR DESCRIPTION
### Description

- In `asyncio.as_completed()`, when timeouts happen, pending tasks are now cancelled.
- In `builtins.zip()`, uses gather with `return_exceptions=True` to prevent leftover, unawaited tasks.
- Creates a fresh event loop for each test case, and closes that after test completion, to help debug and uncover pending tasks.

Fixes: #67
