### PR TITLE
Fix docstring of `builtins.max`

### DIFF
--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -229,7 +229,7 @@ async def max(itr: AnyIterable[Orderable], **kwargs: Any) -> Any:
 
     Example::
 
-        await min(range(5))
+        await max(range(5))
         -> 4
 
     """


### PR DESCRIPTION
### Description

I have fixed docstring of `builtins.max`. Very tiny fix.

Fixes: 
- Fixed docstring (in `aioitertools/builtins.py:232`)