### PR TITLE
Remove loop parameters from asyncio functions

### DIFF
--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -24,15 +24,12 @@ from typing import (
 )
 
 from .builtins import iter as aiter, maybe_await
-from .helpers import deprecated_wait_param
 from .types import AnyIterable, AsyncIterator, MaybeAwaitable, T
 
 
-@deprecated_wait_param
 async def as_completed(
     aws: Iterable[Awaitable[T]],
     *,
-    loop: Optional[asyncio.AbstractEventLoop] = None,
     timeout: Optional[float] = None,
 ) -> AsyncIterator[T]:
     """
@@ -171,10 +168,8 @@ async def as_generated(
                 pass
 
 
-@deprecated_wait_param
 async def gather(
     *args: Awaitable[T],
-    loop: Optional[asyncio.AbstractEventLoop] = None,
     return_exceptions: bool = False,
     limit: int = -1,
 ) -> List[Any]:
@@ -252,10 +247,8 @@ async def gather(
     return ret
 
 
-@deprecated_wait_param
 async def gather_iter(
     itr: AnyIterable[MaybeAwaitable[T]],
-    loop: Optional[asyncio.AbstractEventLoop] = None,
     return_exceptions: bool = False,
     limit: int = -1,
 ) -> List[T]:

--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -3,11 +3,9 @@
 
 import inspect
 import sys
-import warnings
-from functools import wraps
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Union
 
-from .types import P, R, T
+from .types import T
 
 if sys.version_info < (3, 8):  # pragma: no cover
     from typing_extensions import Protocol
@@ -27,19 +25,3 @@ async def maybe_await(object: Union[Awaitable[T], T]) -> T:
     if inspect.isawaitable(object):
         return await object  # type: ignore
     return object  # type: ignore
-
-
-def deprecated_wait_param(fn: Callable[P, R]) -> Callable[P, R]:
-    @wraps(fn)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        if "loop" in kwargs:  # type: ignore
-            warnings.warn(
-                f"{fn.__name__}() parameter `loop` is deprecated and ignored, "
-                "will be removed in aioitertools v0.11.0",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        return fn(*args, **kwargs)
-
-    return wrapper

--- a/aioitertools/tests/helpers.py
+++ b/aioitertools/tests/helpers.py
@@ -6,7 +6,7 @@ import functools
 import sys
 from unittest import skipIf, TestCase
 
-from aioitertools.helpers import deprecated_wait_param, maybe_await
+from aioitertools.helpers import maybe_await
 
 
 def async_test(fn):
@@ -55,27 +55,3 @@ class HelpersTest(TestCase):
             return a * b
 
         self.assertEqual(await maybe_await(functools.partial(multiply, 6)(7)), 42)
-
-    @async_test
-    async def test_deprecated_wait(self):
-        @deprecated_wait_param
-        async def foo(a, *, loop=None, frob=False):
-            if frob:
-                return a * a
-            else:
-                return a
-
-        self.assertEqual(4, await foo(4))
-        self.assertEqual(16, await foo(4, frob=True))
-
-        with self.assertWarnsRegex(
-            DeprecationWarning, r"foo\(\) parameter `loop` is deprecated"
-        ):
-            result = await foo(9, loop=object(), frob=True)
-            self.assertEqual(81, result)
-
-        with self.assertWarnsRegex(
-            DeprecationWarning, r"foo\(\) parameter `loop` is deprecated"
-        ):
-            result = await foo(5, loop=None)
-            self.assertEqual(5, result)


### PR DESCRIPTION
### Description

This has been deprecated since v0.9.0, and we're about to release v0.11.0, so it's time to pull the plug.
