### PR TITLE
Add `itertools.batched` v3.13 function

### DIFF
--- a/aioitertools/__init__.py
+++ b/aioitertools/__init__.py
@@ -25,6 +25,7 @@ from .builtins import (
 )
 from .itertools import (
     accumulate,
+    batched,
     chain,
     combinations,
     combinations_with_replacement,

--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -5,7 +5,7 @@ import inspect
 import sys
 from typing import Awaitable, Union
 
-from .types import T
+from aioitertools.types import T
 
 if sys.version_info < (3, 8):  # pragma: no cover
     from typing_extensions import Protocol

--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -5,7 +5,7 @@ import inspect
 import sys
 from typing import Awaitable, Union
 
-from aioitertools.types import T
+from .types import T
 
 if sys.version_info < (3, 8):  # pragma: no cover
     from typing_extensions import Protocol

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -68,21 +68,25 @@ async def accumulate(
 
 async def batched(
     iterable: AnyIterable[T],
-    batch_size: int,
+    n: int,
     *,
-    strict=False,
+    strict: bool = False,
 ) -> AsyncIterator[Tuple[T, ...]]:
-    if batch_size < 1:
-        raise ValueError(f"batch size (={batch_size}) must be at least one")
+    """
+    Yield batches of values from the given iterable. The final batch may be shorter.
+
+    Example::
+
+        async for batch in batched(range(15), 5):
+            ...  # (0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12, 13, 14)
+
+    """
+    if n < 1:
+        raise ValueError("n must be at least one")
     aiterator = iter(iterable)
-    while True:
-        batch: Tuple[T, ...] = await tuple(
-            item async for item in islice(aiterator, batch_size)
-        )
-        if not batch:
-            break
-        if strict and len(batch) != batch_size:
-            raise ValueError(f"the batch {batch!r} is incomplete")
+    while batch := await tuple(islice(aiterator, n)):
+        if strict and len(batch) != n:
+            raise ValueError("batched: incomplete batch")
         yield batch
 
 

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -78,6 +78,27 @@ class ItertoolsTest(TestCase):
         self.assertEqual(values, [])
 
     @async_test
+    async def test_batched(self):
+        test_matrix = [
+            ([], 1, []),
+            ([1, 2, 3], 1, [(1,), (2,), (3,)]),
+            ([2, 3, 4], 2, [(2, 3), (4,)]),
+            ([5, 6], 3, [(5, 6)]),
+            (ait.iter([-2, -1, 0, 1, 2]), 2, [(-2, -1), (0, 1), (2,)]),
+        ]
+        for iterable, batch_size, answer in test_matrix:
+            result = [batch async for batch in ait.batched(iterable, batch_size)]
+
+            self.assertEqual(result, answer)
+
+    @async_test
+    async def test_batched_errors(self):
+        with self.assertRaises(ValueError):
+            [batch async for batch in ait.batched([1], 0)]
+        with self.assertRaises(ValueError):
+            [batch async for batch in ait.batched([1, 2, 3], 2, strict=True)]
+
+    @async_test
     async def test_chain_lists(self):
         it = ait.chain(slist, srange)
         for k in ["A", "B", "C", 1, 2, 3]:

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -93,9 +93,9 @@ class ItertoolsTest(TestCase):
 
     @async_test
     async def test_batched_errors(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "n must be at least one"):
             [batch async for batch in ait.batched([1], 0)]
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "incomplete batch"):
             [batch async for batch in ait.batched([1, 2, 3], 2, strict=True)]
 
     @async_test


### PR DESCRIPTION
# Adding itertools.batched function

The implementation is like [this one](https://docs.python.org/3.13/library/itertools.html#itertools.batched) from Python 3.13 release.

The PR is derived from the #176 branch.