### PR TITLE
Fix docstrings and markdown files so sphinx successfully compiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,19 +5,21 @@
 You'll need to have Python 3.8 or newer available for testing.
 I recommend using [pyenv][] for this:
 
-    $ pyenv install 3.12
-    $ pyenv shell 3.12
-
+```sh
+$ pyenv install 3.12
+$ pyenv shell 3.12
+```
 
 ## Setup
 
 Create a fresh development enviroment, and install the
 appropriate tools and dependencies:
 
-    $ cd <path/to/aioitertools>
-    $ make venv
-    $ source .venv/bin/activate
-
+```sh
+$ cd <path/to/aioitertools>
+$ make venv
+$ source .venv/bin/activate
+```
 
 ## Submitting
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Install
 aioitertools requires Python 3.8 or newer.
 You can install it from PyPI:
 
-    $ pip install aioitertools
-
+```sh
+$ pip install aioitertools
+```
 
 Usage
 -----

--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -253,7 +253,7 @@ async def gather_iter(
     limit: int = -1,
 ) -> List[T]:
     """
-    Wrapper around gather to handle gathering an iterable instead of *args.
+    Wrapper around gather to handle gathering an iterable instead of ``*args``.
 
     Note that the iterable values don't have to be awaitable.
     """


### PR DESCRIPTION
### Description

Running sphinx to create the documentation gave errors on three files; this PR tweaks two markdown files and one docstring so that sphinx is successful.