### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -7,10 +7,7 @@ from typing import Awaitable, Union
 
 from .types import T
 
-if sys.version_info < (3, 8):  # pragma: no cover
-    from typing_extensions import Protocol
-else:  # pragma: no cover
-    from typing import Protocol
+from typing import Protocol
 
 
 class Orderable(Protocol):  # pragma: no cover


### PR DESCRIPTION
Filter all code over `pyupgracde --py38-plus`.

### Description

<describe bug fix or new feature>

Fixes: #
